### PR TITLE
Remove lexical-binding

### DIFF
--- a/ember-yasnippets.el
+++ b/ember-yasnippets.el
@@ -1,4 +1,4 @@
-;;; ember-yasnippets.el --- Snippets for Ember.js development  -*- lexical-binding: t; -*-
+;;; ember-yasnippets.el --- Snippets for Ember.js development
 
 ;; Copyright (C) 2015  Ron White
 


### PR DESCRIPTION
This is unused and implies an Emacs 24 dependency.
